### PR TITLE
fix checkboxes not saving after GF 1.9

### DIFF
--- a/gfcptaddon.php
+++ b/gfcptaddon.php
@@ -3,7 +3,7 @@
 Plugin Name: Gravity Forms + Custom Post Types
 Plugin URI: http://themergency.com/plugins/gravity-forms-custom-post-types/
 Description: Allows a simple way to map a Gravity Form post entry to a custom post type. Also include custom taxonomies.
-Version: 3.0.1
+Version: 3.0.2
 Author: Brad Vincent
 Author URI: http://themergency.com/
 License: GPL2

--- a/gfcptaddonbase.php
+++ b/gfcptaddonbase.php
@@ -245,8 +245,8 @@ if (!class_exists('GFCPTAddonBase')) {
          * setup a field if it is linked to a post type
          */
         function setup_post_type_field( &$field, $post_type ) {
-            $first_choice = $field['choices'][0]['text'];
-            $field['choices'] = $this->load_post_type_choices( $post_type, $first_choice );
+            $first_choice = $field->choices[0]['text'];
+            $field->choices = $this->load_post_type_choices( $post_type, $first_choice );
         }
 
         function load_post_type_choices($post_type, $first_choice = '') {
@@ -298,8 +298,8 @@ if (!class_exists('GFCPTAddonBase')) {
          * setup a field if it is linked to a taxonomy
          */
         function setup_taxonomy_field( &$field, $taxonomy ) {
-            $first_choice = $field['choices'][0]['text'];
-            $field['choices'] = $this->load_taxonomy_choices( $taxonomy, $field['type'], $first_choice );
+            $first_choice = $field->choices[0]['text'];
+            $field->choices = $this->load_taxonomy_choices( $taxonomy, $field['type'], $first_choice );
 
             //now check if we are dealing with a checkbox list and do some extra magic
             if ( $field['type'] == 'checkbox' ) {
@@ -308,14 +308,14 @@ if (!class_exists('GFCPTAddonBase')) {
 
                 $counter = 0;
                 //recreate the inputs so they are captured correctly on form submission
-                foreach( $field['choices'] as $choice ) {
+                foreach( $field->choices as $choice ) {
                     $counter++;
                     if ( ($counter % 10) == 0 ) $counter++; //thanks to Peter Schuster for the help on this fix
                     $id = floatval( $field['id'] . '.' . $counter );
                     $inputs[] = array('label' => $choice['text'], 'id' => $id);
                 }
 
-                $field['inputs'] = $inputs;
+                $field->inputs = $inputs;
             }
         }
 
@@ -404,7 +404,7 @@ if (!class_exists('GFCPTAddonBase')) {
         function save_taxonomy_field( &$field, $entry, $taxonomy ) {
             if ( array_key_exists( 'type', $field ) && $field['type'] == 'checkbox' ) {
                 $term_ids = array();
-                foreach ( $field['inputs'] as $input ) {
+                foreach ( $field->inputs as $input ) {
                     $term_id = (int) $entry[ (string) $input['id'] ];
                     if ( $term_id > 0 )
                         $term_ids[] = $term_id;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: bradvin
 Donate link: http://themergency.com/donate/
 Tags: form,forms,gravity,gravity form,gravity forms,CPT,custom post types,custom post type,taxonomy,taxonomies
 Requires at least: 3.0.1
-Tested up to: 3.3.1
+Tested up to: 4.1.1
 Stable tag: 3.0.1
 
 Easily map your forms that create posts to a custom post type. Also map dropdown select, radio buttons list and checkboxes lists to a custom taxonomy.


### PR DESCRIPTION
checkboxes and taxonomies were not saving properly after GF 1.9 update
which changes $fields to be an object instead of associate array.
version bump. updated "Tested up to" was outdated. didn't change stable tag.